### PR TITLE
Create `robots.txt` and add to site with disallowed pages

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -3,6 +3,7 @@ baseURL = "http://mudmap.io/"
 title = "Mudmap | pfSense Remote Management"
 theme = ["website-theme", "plausible-hugo"]
 
+enableRobotsTXT = true
 # post pagination
 paginate = "3"
 # post excerpt

--- a/content/english/stack/_index.md
+++ b/content/english/stack/_index.md
@@ -1,1 +1,3 @@
-software stack TBC
+---
+robotsdisallow: true
+---

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,15 @@
+
+User-agent: *
+
+{{ range where .Data.Pages "Params.robotsdisallow" true }}
+Disallow: {{ .RelPermalink }}
+{{ end }}
+Disallow: /app/
+
+Disallow: /login/
+
+Disallow: /logout/
+
+Disallow: /register/
+
+Sitemap: {{ "index.xml" | absLangURL }}


### PR DESCRIPTION
Create a `robots.txt` file.

All pages are allowed by default unless specified in the page with `params.disallowrobots = true`. 